### PR TITLE
Migrate production deployment to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,33 +1,25 @@
-# Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to Pages
+name: Deploy Hugo site to Cloudflare Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
-# Default to bash
 defaults:
   run:
     shell: bash
 
 jobs:
-  # Build job
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.159.1
@@ -40,36 +32,23 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
       - name: Update .netrc
-        id: netrc
         run: |
           echo "machine github.com login ${{ secrets.GH_AUTH_TOKEN }} password x-oauth-basic" > $HOME/.netrc
       - name: Build with Hugo
         env:
-          # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
           hugo \
             --logLevel info \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+            --baseURL "https://stevebennett.co/"
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
         with:
-          path: ./public
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: stevebennett-prod
+          directory: ./public
+          branch: main


### PR DESCRIPTION
## Summary
- Replaces GitHub Pages deployment with Cloudflare Pages for the production site
- Uses the same build and deploy pattern as the beta site (`beta-pages.yml`)
- Removes GitHub Pages-specific actions (`configure-pages`, `upload-pages-artifact`, `deploy-pages`) and unnecessary permissions (`pages: write`, `id-token: write`)

## Post-merge steps
- Disable GitHub Pages in repo settings (Settings > Pages > Source: None)
- Verify `stevebennett.co` resolves to the Cloudflare Pages deployment

## Test plan
- [ ] Merge PR and confirm the workflow runs successfully on `main`
- [ ] Verify `https://stevebennett.co/` loads correctly from Cloudflare Pages
- [ ] Verify `https://beta.stevebennett.co/` is unaffected
- [ ] Disable GitHub Pages in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)