### PR TITLE
feat: update CI and Dockerfile for Tailwind build

### DIFF
--- a/.github/workflows/beta-pages.yml
+++ b/.github/workflows/beta-pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/beta-pages.yml
+++ b/.github/workflows/beta-pages.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Update .netrc
         run: |
           echo "machine github.com login ${{ secrets.GH_AUTH_TOKEN }} password x-oauth-basic" > $HOME/.netrc
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install npm dependencies
+        run: npm ci
       - name: Build with Hugo
         env:
           HUGO_ENVIRONMENT: production

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,6 +47,13 @@ jobs:
         id: netrc
         run: |
           echo "machine github.com login ${{ secrets.GH_AUTH_TOKEN }} password x-oauth-basic" > $HOME/.netrc
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install npm dependencies
+        run: npm ci
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,49 @@
+name: PR Build Validation
+
+on:
+  pull_request:
+    branches: ["main", "beta"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "pr-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.159.1
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Update .netrc
+        run: |
+          echo "machine github.com login ${{ secrets.GH_AUTH_TOKEN }} password x-oauth-basic" > $HOME/.netrc
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --logLevel info \
+            --minify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM golang:1.23-alpine
 
-# Arguments
-ARG DART_SASS_VERSION=1.98.0
-
-# install git
-RUN apk add --no-cache git curl
+# install git and nodejs
+RUN apk add --no-cache git curl nodejs npm
 
 # install hugo
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community hugo
@@ -12,12 +9,12 @@ RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/c
 # test go
 RUN go version
 
-# install dart-sass
-RUN curl -sSL https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz | tar -xz -C /opt && \
-  ln -s /opt/dart-sass/sass /usr/local/bin/sass
-
 # set the workdir
 WORKDIR /site
+
+# install npm dependencies for PostCSS/Tailwind
+COPY package*.json ./
+RUN npm ci
 
 # expose the default port
 EXPOSE 1313


### PR DESCRIPTION
## Summary

Closes #93

- Add `actions/setup-node@v4` (Node.js 20 with npm cache) and `npm ci` steps to `pages.yml` and `beta-pages.yml` workflows before the Hugo build
- Replace dart-sass with Node.js/npm in the Dockerfile and add `npm ci` for PostCSS/Tailwind dependencies
- No changes to `notes-autopr.yml` — it only runs `hugo mod` commands, not a site build

## Test plan

- [ ] Verify beta CI workflow passes with the new Node.js + npm ci steps
- [ ] Verify Docker build succeeds: `docker build -t stevebennett-site .`
- [ ] Verify Hugo build completes with PostCSS/Tailwind processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)