### PR TITLE
feat: implement dark mode with system preference and manual toggle

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 @plugin "@tailwindcss/typography";
 
 /* Google Fonts */

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,13 +26,20 @@
   {{ partial "footer.html" . }}
 
   <script>
-    var toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      toggle.addEventListener('click', function() {
-        var isDark = document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    (function() {
+      var toggle = document.getElementById('theme-toggle');
+      if (toggle) {
+        toggle.addEventListener('click', function() {
+          var isDark = document.documentElement.classList.toggle('dark');
+          localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+      }
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+        if (!localStorage.getItem('theme')) {
+          document.documentElement.classList.toggle('dark', e.matches);
+        }
       });
-    }
+    })();
   </script>
 </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12.75 19.5v-.75a7.5 7.5 0 00-7.5-7.5H4.5m0-6.75h.75c7.87 0 14.25 6.38 14.25 14.25v.75M6 18.75a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
         </a>
       </nav>
-      <button id="theme-toggle" class="text-zinc-400 dark:text-zinc-500 hover:text-accent dark:hover:text-accent transition-colors" aria-label="Toggle dark mode">
+      <button id="theme-toggle" class="text-zinc-400 dark:text-zinc-500 hover:text-accent dark:hover:text-accent transition-colors rounded-md p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-zinc-900" aria-label="Toggle dark mode">
         <svg class="hidden dark:block w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
         </svg>


### PR DESCRIPTION
## Summary

Closes #91

- Add `@custom-variant dark` declaration in `main.css` for Tailwind v4 class-based dark mode — without this, all `dark:` utility classes across every template were resolving to the `prefers-color-scheme` media query instead of the `.dark` class strategy
- Add `matchMedia` change listener in `baseof.html` so live OS preference changes are reflected when no manual override is set in `localStorage`
- Add `focus-visible` ring styling to the theme toggle button in `header.html` for keyboard accessibility

## Test plan

- [x] Toggle dark mode via the header button — verify styles switch correctly
- [x] Remove `theme` from localStorage, change OS dark mode preference — verify site follows
- [x] Set manual override via toggle, change OS preference — verify manual override is preserved
- [x] Tab to the toggle button — verify focus ring appears
- [x] Verify no FOUC on page load in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)