### PR TITLE
feat: add highlighted and category frontmatter to posts

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,7 @@
----
-title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date }}
-draft: true
----
-
++++
+title = "{{ replace .Name "-" " " | title }}"
+date = {{ .Date }}
+draft = true
+category = ""
+highlighted = false
++++

--- a/content/posts/9-months-really.md
+++ b/content/posts/9-months-really.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "9-months-really"
 title = "9 months! Really?"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 It's been almost nine months since my last blog entry. I've never been a prolific writer as you can see this in the gaps between posts. I think I've found the reason why.

--- a/content/posts/a-tester-in-development.md
+++ b/content/posts/a-tester-in-development.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "a-tester-in-development"
 title = "A tester in development"
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 Ben has superpowers. He's no different to any of us in that way.

--- a/content/posts/an-api-for-teams.md
+++ b/content/posts/an-api-for-teams.md
@@ -5,6 +5,9 @@ description = ""
 draft = false
 slug = "an-api-for-teams"
 title = "An API for Teams"
+category = "Engineering Management"
+tags = ["Engineering Management"]
+highlighted = true
 +++
 
 > “In computer programming, an Application Programming Interface (API) is a set of routine definitions, protocols, and tools for building software an applications A good API makes it easier to develop a program by providing all the building blocks, which are then put together by the programmer.”

--- a/content/posts/an-updated-joel-test.md
+++ b/content/posts/an-updated-joel-test.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "an-updated-joel-test"
 title = "An updated Joel Test"
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 Wow.

--- a/content/posts/are-you-ok.md
+++ b/content/posts/are-you-ok.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "are-you-ok"
 title = "Are you ok?"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 Life is weird right now. It's like nothing I've ever experienced before and everyone reading this is likely to have undergone significant changes to the way they live, work and play.

--- a/content/posts/book-review-extreme-programming-explained.md
+++ b/content/posts/book-review-extreme-programming-explained.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "book-review-extreme-programming-explained"
 title = "Book Review: Extreme Programming Explained"
-
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 I'm lucky enough, at least in my opinion, to work in a team that values extreme programming practices. It's not true of every team at eBay, but it's a growing trend. Extreme Programming (XP) is something I'm comfortable with, and I hope to help other teams see the benefits, and start to put some of the practices into play.

--- a/content/posts/books-from-2016-part-one.md
+++ b/content/posts/books-from-2016-part-one.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "books-from-2016-part-one"
 title = "Books from 2016 - Part One"
+category = "Engineering Management"
+tags = ["Engineering Management"]
 +++
 
 At the start of 2016, I made a resolution to read more. I managed to do this, and read more this year than I've been able to do in recent years. Most of my choices have been leadership or management books, or those related to sport. It's also been mostly non-fiction.

--- a/content/posts/books-from-2016-part-two.md
+++ b/content/posts/books-from-2016-part-two.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "books-from-2016-part-two"
 title = "Books from 2016 - Part Two"
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 This is part two of my review of books I've read in 2016. [Part One can be found here]({{< ref "/posts/books-from-2016-part-one.md" >}}).

--- a/content/posts/can-one-team-do-it-all.md
+++ b/content/posts/can-one-team-do-it-all.md
@@ -1,8 +1,12 @@
----
-title: "Can One Team Do It All?"
-date: 2023-01-10T20:36:38Z
-draft: false
----
++++
+author = "Steve Bennett"
+date = 2023-01-10T20:36:38Z
+draft = false
+slug = "can-one-team-do-it-all"
+title = "Can One Team Do It All?"
+category = "Engineering Management"
+tags = ["Engineering Management"]
++++
 
 Once you've worked on a few different software projects, you notice that different processes tend to work better for some and not others. 
 

--- a/content/posts/career-development-planning-questions.md
+++ b/content/posts/career-development-planning-questions.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "career-development-planning-questions"
 title = "Career Development Planning Questions"
+category = "Engineering Management"
+tags = ["Engineering Management"]
 +++
 
 Part of the role of an Engineering Manager is to help others to achieve their career aspirations. However, it's not always easy for people to articulate the direction they hope their career will take them. For some, it can be difficult to describe their ideal future role, or to answer that "where will you be in 5 years time?" question.

--- a/content/posts/career-paths-and-circles/index.md
+++ b/content/posts/career-paths-and-circles/index.md
@@ -5,6 +5,9 @@ description = ""
 draft = false
 slug = "career-paths-and-circles"
 title = "Career Paths and Circles"
+category = "Engineering Management"
+tags = ["Engineering Management"]
+highlighted = true
 +++
 
 I’ve been spending a fair amount of time recently reworking our career paths. Our current documents are heavily based on the work by [Radford](https://radford.aon.com/), which defines 6 levels for each job family. Whilst our career path was very well defined and comprehensive, we are finding that the documentation is a little incomprehensible and causes difficulty as people try to self-assess their position on the career path.

--- a/content/posts/comparing-the-performance-of-agile-teams/index.md
+++ b/content/posts/comparing-the-performance-of-agile-teams/index.md
@@ -5,6 +5,9 @@ description = ""
 draft = false
 slug = "comparing-the-performance-of-agile-teams"
 title = "Comparing the performance of agile teams"
+category = "Agile"
+tags = ["Agile"]
+highlighted = true
 +++
 
 Recently I got into a conversation about measuring the performance of Engineering teams. The teams in question are following the Scrum framework and have decided to use story points for estimating the complexity of the work.

--- a/content/posts/developing-without-a-safety-net.md
+++ b/content/posts/developing-without-a-safety-net.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "developing-without-a-safety-net"
 title = "Developing without a Safety Net"
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 Recently, an article about the [changes to the development process at Yahoo](http://spectrum.ieee.org/view-from-the-valley/computing/software/yahoos-engineers-move-to-coding-without-a-net) caught my eye. In a move to improve quality, speed and efficiency, Yahoo removed the "QA Team" from their development process. According to the article, the change resulted in an increased focus on automation. Checks previously completed by "error-prone" humans were now done by code. If the checks passed, the code went live.

--- a/content/posts/engineering-managers-slack-team.md
+++ b/content/posts/engineering-managers-slack-team.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "engineering-managers-slack-team"
 title = "Engineering Managers Slack Team"
-
+category = "Engineering Management"
+tags = ["Engineering Management"]
 +++
 
 ### 🗣 Calling all Engineering Managers! 🗣

--- a/content/posts/finding-great-places-to-work.md
+++ b/content/posts/finding-great-places-to-work.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "finding-great-places-to-work"
 title = "Finding great places to work"
-
+category = "Personal"
+tags = ["Personal"]
 +++
 
 {{< x user="stevebennett" id="832566920012521473" >}}

--- a/content/posts/getting-better-feedback.md
+++ b/content/posts/getting-better-feedback.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "getting-better-feedback"
 title = "Getting better feedback"
+category = "Engineering Management"
+tags = ["Engineering Management"]
 +++
 
 In many organisations, the request for feedback comes as part of a performance review cycle. During this process, an individual will review their goals, assess their career development plan and reflect on feedback from their peers.

--- a/content/posts/im-new-to-engineering-management-what-books-should-i-read.md
+++ b/content/posts/im-new-to-engineering-management-what-books-should-i-read.md
@@ -5,8 +5,10 @@ date = 2020-04-22T13:24:21Z
 description = ""
 draft = false
 slug = "im-new-to-engineering-management-what-books-should-i-read"
-tags = ["newtothis"]
+tags = ["newtothis", "Engineering Management"]
 title = "I'm new to Engineering Management, what books should I read?"
+category = "Engineering Management"
+highlighted = true
 +++
 
 There are so many great books that I could recommend for a new manager. Narrowing down the list has been challenging!

--- a/content/posts/im-new-to-this-what-do-you-recommend.md
+++ b/content/posts/im-new-to-this-what-do-you-recommend.md
@@ -5,9 +5,9 @@ date = 2020-04-21T12:42:50Z
 description = ""
 draft = false
 slug = "im-new-to-this-what-do-you-recommend"
-tags = ["newtothis"]
+tags = ["newtothis", "Engineering Management"]
 title = "I'm new to this, what do you recommend?"
-
+category = "Engineering Management"
 +++
 
 Recently I was asked what resources I would recommend for someone moving from an engineering role and taking on a management role. Many people become a manager without clear training and development plan in place from their employer.

--- a/content/posts/lead-dev-london-2017-field-report.md
+++ b/content/posts/lead-dev-london-2017-field-report.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "lead-dev-london-2017-field-report"
 title = "Lead Dev London 2017 Field Report"
+category = "Conference Reports"
+tags = ["Conference Reports"]
 +++
 
 I was fortunate enough to spend the last couple of days at [Lead Developer 2017](http://2017.theleaddeveloper.com) in London. The conference has been described as a leadership and management conference dressed up as a technical conference. It’s one of my “must-attend” conferences of the year.

--- a/content/posts/life-at-hibu.md
+++ b/content/posts/life-at-hibu.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "life-at-hibu"
 title = "Life at hibu"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 This post has been sitting in my drafts folder for almost a year now, and the relaunch of my blog is a great opportunity to get it out there.

--- a/content/posts/living-in-the-echo-chamber/index.md
+++ b/content/posts/living-in-the-echo-chamber/index.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "living-in-the-echo-chamber"
 title = "Living in the Echo Chamber"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 Yesterday was a momentous day in British history.

--- a/content/posts/micro-frustrations.md
+++ b/content/posts/micro-frustrations.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "micro-frustrations"
 title = "Micro-Frustrations"
+category = "Engineering Management"
+tags = ["Engineering Management"]
 +++
 
 What are the little things that annoy you in your current role?

--- a/content/posts/my-guide-to-technical-telephone-interviews.md
+++ b/content/posts/my-guide-to-technical-telephone-interviews.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "my-guide-to-technical-telephone-interviews"
 title = "My guide to technical telephone interviews"
+category = "Hiring"
+tags = ["Hiring"]
 +++
 
 Such is my life at the moment, I started writing this article on my smartphone whilst commuting home from work. The reason for this? I'm busy at the moment because my team is hiring.

--- a/content/posts/navigation-and-pair-programming.md
+++ b/content/posts/navigation-and-pair-programming.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "navigation-and-pair-programming"
 title = "Navigation and Pair Programming"
-
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 I’ve become a bit of a fan of pair programming over the years. I enjoy working through problems with another developer, as I find it usually leads to a deeper understanding of the problem, the domain and the improves the quality of the code that is produced. I also almost always learn something.

--- a/content/posts/on-leaving-alfresco.md
+++ b/content/posts/on-leaving-alfresco.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "on-leaving-alfresco"
 title = "On Leaving Alfresco"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 This week, after over 3 and a half years, I left Alfresco. The decision to leave was a difficult one, but ultimately, it's the right move for both the company and me.

--- a/content/posts/oredev-2014-day-one.md
+++ b/content/posts/oredev-2014-day-one.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "oredev-2014-day-one"
 title = "Øredev 2014 - Day One"
+category = "Conference Reports"
+tags = ["Conference Reports"]
 +++
 
 

--- a/content/posts/oredev-2014-day-three.md
+++ b/content/posts/oredev-2014-day-three.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "oredev-2014-day-three"
 title = "Øredev 2014 - Day Three"
+category = "Conference Reports"
+tags = ["Conference Reports"]
 +++
 
 I've finally got round to adding my notes from the final day of Øredev 2014. It's taken a little longer than I anticipated due to travel and work commitments. You can find the rest of my notes in [part one]({{< ref "/posts/oredev-2014-day-one.md" >}}) and [part two]({{< ref "/posts/oredev-2014-day-two.md" >}}).

--- a/content/posts/oredev-2014-day-two.md
+++ b/content/posts/oredev-2014-day-two.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "oredev-2014-day-two"
 title = "Øredev 2014 - Day Two"
+category = "Conference Reports"
+tags = ["Conference Reports"]
 +++
 
 This is the second in a three part series giving an overview of the sessions I attended at Øredev 2014. Part one of the series can be found [here]({{< ref "/posts/oredev-2014-day-one.md" >}}).

--- a/content/posts/owning-your-mistakes.md
+++ b/content/posts/owning-your-mistakes.md
@@ -5,6 +5,9 @@ description = ""
 draft = false
 slug = "owning-your-mistakes"
 title = "Owning your mistakes"
+category = "Engineering Management"
+tags = ["Engineering Management"]
+highlighted = true
 +++
 
 I believe that one of the most powerful things you can do as a leader is to own your mistakes. Nobody is perfect, and therefore it’s inevitable that you will make mistakes. Often, holding a leadership or management position means that these mistakes are magnified and have a impact on many more people.

--- a/content/posts/putting-facebook-on-pause.md
+++ b/content/posts/putting-facebook-on-pause.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "putting-facebook-on-pause"
 title = "Putting Facebook on Pause"
+category = "Personal"
+tags = ["Personal"]
 +++
 
 In the week that [Facebook turned 10,](http://www.theguardian.com/technology/2014/feb/04/facebook-10-years-mark-zuckerberg) I decided to rethink my own use of the social network.

--- a/content/posts/removing-facebook-again.md
+++ b/content/posts/removing-facebook-again.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "removing-facebook-again"
 title = "Removing Facebook (again)"
-
+category = "Personal"
+tags = ["Personal"]
 +++
 
 {{< x user="stevebennett" id="976019846889705472" >}}

--- a/content/posts/screening-technical-cvs.md
+++ b/content/posts/screening-technical-cvs.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "screening-technical-cvs"
 title = "Screening technical CVs"
+category = "Hiring"
+tags = ["Hiring"]
 +++
 
 Recently I've been spending a great deal of time screening technical CVs. What struck me during this process is generally how bad engineering CVs are.

--- a/content/posts/stop-mocking-me.md
+++ b/content/posts/stop-mocking-me.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "stop-mocking-me"
 title = "Stop mocking me"
-
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 Unit testing can be hard. And it gets harder when you have to test code with with external dependencies. The way you deal with this will depend on whether you are a [classical or mockist programmer](http://martinfowler.com/articles/mocksArentStubs.html#ClassicalAndMockistTesting). Most people don't exist at the extremes, but instead are somewhere along the line. This isn't a bad thing. Being pragmatic in your decisions shows that you're a [mature engineer](http://www.sbio.me/blog/2015/1/26/thinking-about-senior-engineers).

--- a/content/posts/the-future-for-manual-testing.md
+++ b/content/posts/the-future-for-manual-testing.md
@@ -5,6 +5,8 @@ description = ""
 draft = false
 slug = "the-future-for-manual-testing"
 title = "The future for manual testing"
+category = "Software Engineering"
+tags = ["Software Engineering"]
 +++
 
 Is being a manual tester a dead-end career as [@jsonmez](http://www.twitter.com/jsonmez) says in his video response for Simple Programmer?

--- a/content/posts/the-power-of-sensible-defaults.md
+++ b/content/posts/the-power-of-sensible-defaults.md
@@ -5,6 +5,9 @@ description = ""
 draft = false
 slug = "the-power-of-sensible-defaults"
 title = "The Power of Sensible Defaults"
+category = "Engineering Management"
+tags = ["Engineering Management"]
+highlighted = true
 +++
 
 Choosing the “best tool for the job” is a mantra that many software engineers repeat when asked to explain their choice of tool, language or framework. In some cases, this choice is right, however far too many times in my career I’ve seen “best tool for the job” loosely translate to whatever was top of Hacker News this week.

--- a/content/posts/thinking-about-senior-engineers.md
+++ b/content/posts/thinking-about-senior-engineers.md
@@ -5,7 +5,9 @@ description = ""
 draft = false
 slug = "thinking-about-senior-engineers"
 title = "Thinking about Senior Engineers"
-
+category = "Software Engineering"
+tags = ["Software Engineering"]
+highlighted = true
 +++
 
 What makes a person a Senior Software Engineer? Is it their technical knowledge? The amount of languages, libraries or development techniques they know? Or maybe it's just an indicator of the number of years experience they have?

--- a/content/posts/using-goals-for-effective-iterations.md
+++ b/content/posts/using-goals-for-effective-iterations.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "using-goals-for-effective-iterations"
 title = "Setting goals for effective iterations"
-
+category = "Agile"
+tags = ["Agile"]
 +++
 
 All agile teams building software do it every day. The time might vary. Ours is at 9.45am. Some do it just before lunch, others at the end of the day but if you're working in an agile team, it's likely that you have a daily stand-up.

--- a/content/posts/waiter-theres-test-in-my-dev-oredev-2014.md
+++ b/content/posts/waiter-theres-test-in-my-dev-oredev-2014.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "waiter-theres-test-in-my-dev-oredev-2014"
 title = "Waiter, there's test in my dev! - Øredev 2014"
-
+category = "Conference Reports"
+tags = ["Conference Reports"]
 +++
 
 This week I completed my first talk at a major developer conference, [Øredev](http://www.oredev.org/2014) in Malmö. I found it both nerve-racking and exciting in the lead up to the talk, but once I got started I soon settled in and concentrated on the content.

--- a/content/posts/what-is-acceptance-criteria.md
+++ b/content/posts/what-is-acceptance-criteria.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "what-are-acceptance-criteria"
 title = "What are Acceptance Criteria?"
-
+category = "Agile"
+tags = ["Agile"]
 +++
 
 How do you know when something is "Done"?

--- a/content/posts/you-can-keep-your-bug-tracker-just-use-it-less.md
+++ b/content/posts/you-can-keep-your-bug-tracker-just-use-it-less.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "you-can-keep-your-bug-tracker-just-use-it-less"
 title = "You can keep your bug-tracker, just use it less!"
-
+category = "Agile"
+tags = ["Agile"]
 +++
 I recently published an article on my blog titled ["You don't need a bug tracker"]({{< ref "/posts/you-dont-need-a-bug-tracker.md" >}}). This article was also syndicated on [DZone](http://css.dzone.com/articles/you-dont-need-bug-tracker). Following the publication I received some feedback on it's contents. I'd like to take this opportunity to clear up a few things.
 

--- a/content/posts/you-dont-need-a-bug-tracker.md
+++ b/content/posts/you-dont-need-a-bug-tracker.md
@@ -5,7 +5,8 @@ description = ""
 draft = false
 slug = "you-dont-need-a-bug-tracker"
 title = "You don't need a bug-tracker"
-
+category = "Agile"
+tags = ["Agile"]
 +++
 
 If you're writing software, chances are you use some sort of issue tracking tool. Or to be more precise, you most likely have a bug tracker. Jira, Bugzilla, heck, even an Excel spreadsheet. If you're diligent every time you find a bug you'll create a ticket in the tool. Most bug-tracking tools will guide you to add a severity and assign a priority. The aim of classifying a defect in this way is to help you know what to work on next. In most systems, the two aren't related. This means you can create defects with "Critical" severity, assigned a "Low priority".


### PR DESCRIPTION
## Summary
- Add `category` and `tags` to all 41 non-draft posts across 6 categories: Engineering Management, Software Engineering, Agile, Hiring, Conference Reports, Personal
- Mark 7 key posts as `highlighted = true` for the homepage
- Convert archetype from YAML to TOML with new fields
- Convert `can-one-team-do-it-all.md` from YAML to TOML for consistency

Closes #96

## Highlighted posts
1. An API for Teams (Engineering Management)
2. The Power of Sensible Defaults (Engineering Management)
3. Owning your mistakes (Engineering Management)
4. Career Paths and Circles (Engineering Management)
5. Thinking about Senior Engineers (Software Engineering)
6. Comparing the performance of agile teams (Agile)
7. I'm new to Engineering Management, what books should I read? (Engineering Management)

## Test plan
- [x] `hugo` builds successfully (82 pages including new tag pages)
- [x] Homepage shows 5 most recent highlighted posts with category labels
- [x] Tag taxonomy pages generated for all 6 categories
- [ ] Verify category links navigate to correct tag pages
- [ ] Verify single post pages show category label

🤖 Generated with [Claude Code](https://claude.com/claude-code)